### PR TITLE
Add an error code for too-old clients.

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -66,6 +66,7 @@ pub enum ApiErrorKind {
     InternalError {},
     MissingOrInvalidAuthToken {},
     NoApiRoute {},
+    NoLongerSupported {},
     NoMatchingExit {},
     RateLimitExceeded {},
     SignupLimitExceeded {},


### PR DESCRIPTION
Eventually we will want to remove support for some API routes or parameter combinations. We are adding this error code now so that we can handle it in clients in preparation for when we need it.

Fixes: https://linear.app/soveng/issue/OBS-900/add-unsupported-error-in-api