### PR TITLE
Introduce `AccountId` type.

### DIFF
--- a/examples/api_cli.rs
+++ b/examples/api_cli.rs
@@ -2,7 +2,7 @@ use anyhow::bail;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use clap::{Parser, Subcommand};
 use obscuravpn_api::cmd::*;
-use obscuravpn_api::types::{TunnelConfig, WgPubkey};
+use obscuravpn_api::types::{AccountId, TunnelConfig, WgPubkey};
 use obscuravpn_api::wg_conf::build_wg_conf;
 use obscuravpn_api::Client;
 use qrcode::QrCode;
@@ -57,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let args = Args::parse();
     let url = args.base_url;
-    let account_id = args.account_no;
+    let account_id = AccountId::from_string_unchecked(args.account_no);
 
     let client = Client::new(url, account_id, "example cli client")?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use crate::cmd::{parse_response, ApiError, ApiErrorKind, Cmd, ProtocolError};
 use crate::token::AcquireToken;
-use crate::types::AuthToken;
+use crate::types::{AccountId, AuthToken};
 use anyhow::{anyhow, Context};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 #[derive(Debug)]
 pub struct Client {
-    account_id: String,
+    account_id: AccountId,
     base_url: String,
     http: reqwest::Client,
     cached_auth_token: Arc<Mutex<Option<AuthToken>>>,
@@ -30,7 +30,7 @@ pub enum ClientError {
 }
 
 impl Client {
-    pub fn new(base_url: impl ToString, account_id: String, user_agent: &str) -> anyhow::Result<Self> {
+    pub fn new(base_url: impl ToString, account_id: AccountId, user_agent: &str) -> anyhow::Result<Self> {
         let mut base_url = base_url.to_string();
         if !base_url.ends_with('/') {
             base_url += "/"

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,9 +1,11 @@
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::types::AccountId;
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AcquireToken {
-    pub account_id: String,
+    pub account_id: AccountId,
 }
 
 impl AcquireToken {

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,9 +6,39 @@ use ipnetwork;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct AccountId(String);
+
+impl AccountId {
+    pub fn from_string_unchecked(id: String) -> Self {
+        AccountId(id)
+    }
+
+    // The digit portion of the account hint.
+    pub fn hint(&self) -> &str {
+        &self.0[0..3]
+    }
+
+    pub fn as_string(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Display for AccountId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::fmt::Debug for AccountId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AccountId({}...)", self.hint())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccountInfo {
-    pub id: String,
+    pub id: AccountId,
     pub active: bool,
     pub top_up: Option<TopUp>,
     pub subscription: Option<Subscription>,


### PR DESCRIPTION
This provides stronger typing and redacts the full account number for `Debug` printing.

For now no checking is provided, but the conversion is made explicit and checking can be added in the future.