### PR TITLE
Add error for creating something twice.

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -71,6 +71,7 @@ pub struct ApiErrorBody {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum ApiErrorKind {
     AccountExpired {},
+    AlreadyExists {},
     BadRequest {},
     InternalError {},
     MissingOrInvalidAuthToken {},


### PR DESCRIPTION
In many cases we just want to act idempotently, but in some cases it isn't suitable. For example this would return the newsletter unsubscribe token to anyone who knows a user's email. Not critical but best to show. It may also be useful for the UI to show a different message for already subscribed and newly subscribed.

The error itself is generic as it can be used for any situation in which the primary object being created already exists.