### PR TITLE
Document OneRelay fields.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -213,12 +213,23 @@ impl Display for WgPubkey {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct OneRelay {
     pub id: String,
-    pub ip_v4: net::Ipv4Addr,
-    pub ip_v6: net::Ipv6Addr,
     pub preferred_exits: Vec<RelayPreferredExit>,
+
+    /// Unused. Set for compatibility with old clients.
+    ///
+    /// https://linear.app/soveng/issue/OBS-1318
+    #[cfg(feature = "server")]
+    #[serde(default = "localhost_ip_v6")]
+    pub ip_v6: net::Ipv6Addr,
+
+    /// The IPv4 address where the QUIC API is available.
+    ///
+    /// The API is available on all of the ports listed in `ports`.
+    pub ip_v4: net::Ipv4Addr,
+    pub ports: Vec<u16>,
+    /// The TLS cert for the QUIC API.
     #[serde_as(as = "Base64")]
     pub tls_cert: Vec<u8>,
-    pub ports: Vec<u16>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -313,4 +324,8 @@ impl From<AuthToken> for String {
     fn from(value: AuthToken) -> Self {
         value.0
     }
+}
+
+fn localhost_ip_v6() -> net::Ipv6Addr {
+    net::Ipv6Addr::LOCALHOST
 }


### PR DESCRIPTION
Right now we don't support IPv6 and we don't know exactly what we will want the API to be in the future if we do. So document what the IPv6 fields mean and remove unused fields so that we don't have to worry about them in the future.

Fixes: https://linear.app/soveng/issue/OBS-1295/dont-return-fake-[1]-addresses-in-api-server-response