### PR TITLE
Add names to tunnels.

### DIFF
--- a/examples/api_cli.rs
+++ b/examples/api_cli.rs
@@ -27,6 +27,8 @@ enum Commands {
     ListTunnels,
     ListRelays,
     CreateObfuscatedTunnel {
+        #[clap(long)]
+        label: Option<String>,
         /// use specific relay
         #[clap(long)]
         relay: Option<String>,
@@ -35,6 +37,8 @@ enum Commands {
         exit: Option<String>,
     },
     CreateStaticTunnel {
+        #[clap(long)]
+        label: Option<String>,
         /// print WireGuard configuration to stdout (JSON to stderr)
         #[clap(long)]
         wg_conf: bool,
@@ -81,7 +85,7 @@ async fn main() -> anyhow::Result<()> {
             let tunnels = client.run(ListTunnels {}).await?;
             println!("{:#?}", tunnels);
         }
-        Commands::CreateObfuscatedTunnel { relay, exit } => {
+        Commands::CreateObfuscatedTunnel { label, relay, exit } => {
             eprintln!("Creating new tunnel");
             let sk = StaticSecret::random_from_rng(OsRng);
             eprintln!("Created private key");
@@ -91,6 +95,7 @@ async fn main() -> anyhow::Result<()> {
             let tunnel = client
                 .run(CreateTunnel::Obfuscated {
                     id: None,
+                    label,
                     wg_pubkey,
                     relay,
                     exit,
@@ -100,7 +105,7 @@ async fn main() -> anyhow::Result<()> {
             eprintln!("Created tunnel {}", &tunnel.id);
             println!("{}", serde_json::to_string_pretty(&tunnel)?);
         }
-        Commands::CreateStaticTunnel { wg_conf, relay, exit } => {
+        Commands::CreateStaticTunnel { label, wg_conf, relay, exit } => {
             eprintln!("Creating new tunnel");
             let sk = StaticSecret::random_from_rng(OsRng);
             let pk = PublicKey::from(&sk);
@@ -113,6 +118,7 @@ async fn main() -> anyhow::Result<()> {
             let tunnel = client
                 .run(CreateTunnel::UdpPort {
                     id: None,
+                    label,
                     wg_pubkey,
                     relay,
                     exit,

--- a/src/cmd/tunnel/create.rs
+++ b/src/cmd/tunnel/create.rs
@@ -9,12 +9,14 @@ use uuid::Uuid;
 pub enum CreateTunnel {
     UdpPort {
         id: Option<Uuid>,
+        label: Option<String>,
         wg_pubkey: WgPubkey,
         relay: Option<String>,
         exit: Option<String>,
     },
     Obfuscated {
         id: Option<Uuid>,
+        label: Option<String>,
         wg_pubkey: WgPubkey,
         relay: Option<String>,
         exit: Option<String>,
@@ -33,6 +35,7 @@ fn test_json() {
     {
         "type": "obfuscated",
         "id": "bd309cd5-e6e7-40b0-82d8-dbacdc827cb6",
+        "label": null,
         "wg_pubkey": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
         "relay": "NYC-001",
         "exit": "NYC-001"
@@ -43,6 +46,61 @@ fn test_json() {
       "id": "dc799918-7738-446f-b1fc-ae3ba98103c7",
       "status": {
         "type": "created",
+        "when": 1725050273
+      },
+      "config": {
+        "type": "obfuscated",
+        "client_pubkey": "wjaiHUEOJ8k3X+U3b6H6yTcipqFipIbFQSB0CwZDNlQ=",
+        "client_ips_v4": ["10.150.177.7/32"],
+        "client_ips_v6": ["fc00:bbbb:bbbb:bb01:d:0:16:b107/128"],
+        "dns": ["10.64.0.1"],
+        "gateway_ip_v4": "10.64.0.1",
+        "relay_addr_v4": "8.8.31.3:443",
+        "relay_addr_v6": "[2001:db8:1234:ffff:ffff:ffff:ffff:ffff]:443",
+        "relay_cert": "asdf",
+        "exit_pubkey": "4s9JIhxC/D02tosXYYcgrD+pHI+C7oTAFsXzVisKjRs="
+      },
+      "relay": {
+        "id": "NYC-001",
+        "ip_v4": "8.8.31.3",
+        "ip_v6": "2001:db8:1234:ffff:ffff:ffff:ffff:ffff",
+        "preferred_exits": [{ "id": "nyc-wg-30" }],
+        "tls_cert": "MIIBWjCCAQGgAwIBAgIVAK3WuHUPFg+mmBGiDhW9VNjDmudKMAoGCCqGSM49BAMCMCExHzAdBgNVBAMMFnJjZ2VuIHNlbGYgc2lnbmVkIGNlcnQwIBcNNzUwMTAxMDAwMDAwWhgPNDA5NjAxMDEwMDAwMDBaMCExHzAdBgNVBAMMFnJjZ2VuIHNlbGYgc2lnbmVkIGNlcnQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASLPcQhOgBGP8HRlGBy6rTO7SWnGgSuCEW6hi+Q/wnUr8H9FkJC7UGD9738XGKEq35ZKybrekr0DbK8YsVZ8SX+oxQwEjAQBgNVHREECTAHggVyZWxheTAKBggqhkjOPQQDAgNHADBEAiAYnVn/bozbp6u0iShFfUgbdGvAvf/hXwLhgonj+Fh+xAIgUgfQqvWFPbh3BNu98LhNFrESngTHtYYAOWt3wZdQOm4=",
+        "ports": [53, 443]
+      },
+      "exit": {
+        "id": "NYC-001",
+        "country_code": "US",
+        "city_code": "nyc",
+        "city_name": "New York",
+        "provider_id": "us-nyc-wg-301",
+        "provider_url": "https://mullvad.net/servers",
+        "provider_name": "Mullvad VPN",
+        "provider_homepage_url": "https://mullvad.net"
+      }
+    }
+    "#;
+    crate::cmd::check_cmd_json::<CreateTunnel>(Some(cmd_json), Some(output_json));
+}
+
+#[test]
+fn test_json_named() {
+    let cmd_json = r#"
+    {
+        "type": "obfuscated",
+        "label": "Banking",
+        "id": "bd309cd5-e6e7-40b0-82d8-dbacdc827cb6",
+        "wg_pubkey": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
+        "relay": "NYC-001",
+        "exit": "NYC-001"
+    }
+    "#;
+    let output_json = r#"
+    {
+      "id": "3f221f13-7002-458d-a447-595aba1a372d",
+      "label": "Banking",
+      "status": {
+        "type": "disconnected",
         "when": 1725050273
       },
       "config": {

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,9 +95,22 @@ impl Subscription {
     }
 }
 
+/// The maximum length that a tunnel label can be set to.
+///
+/// Clients should not assume anything about labels that they receive, except that they can comfortably fit in memory on basically any modern device.
+pub const TUNNEL_LABEL_MAX_BYTES: usize = 128;
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct OneTunnel {
     pub id: String,
+
+    /// A user-provided label for the tunnel.
+    ///
+    /// If None, the user did not provide a label and the client should show some nice representation of this, for example the ID and last active time.
+    ///
+    /// The string itself will never be empty (0 bytes) but clients may wish consider cases such as all whitespace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
     pub status: TunnelStatus,
     pub config: TunnelConfig,
     pub relay: OneRelay,


### PR DESCRIPTION
I went back and forth on the representation of this. For example making it an always-present string that may be empty and empty means not set. This is nice because it removes one possible value from the type. However I decided to go with `Option` so that handling the basic flow is natural even if the ideal UX would do things like `tunnel.name.filter(|s| s.is_all_whitespace())`. The API will treat `Some("")` and `None` identically on input to effectively remove this case even if it is possible in the type definitions. Furthermore these cleanups should really be done on the client if they are done at all.

Fixes: https://linear.app/soveng/issue/OBS-1462/add-names-to-tunnels