### PR TITLE
Support making conditional requests.

### DIFF
--- a/examples/api_cli.rs
+++ b/examples/api_cli.rs
@@ -23,7 +23,10 @@ struct Args {
 
 #[derive(Subcommand, Debug, PartialEq)]
 enum Commands {
-    ListExits,
+    ListExits {
+        #[clap(long)]
+        etag: Option<String>,
+    },
     ListTunnels,
     ListRelays,
     CreateObfuscatedTunnel {
@@ -75,10 +78,15 @@ async fn main() -> anyhow::Result<()> {
             let relays = client.run(ListRelays {}).await?;
             println!("{}", serde_json::to_string_pretty(&relays)?);
         }
-        Commands::ListExits => {
+        Commands::ListExits { etag } => {
             eprintln!("Get all exits");
-            let exits = client.run(ListExits2 {}).await?.exits;
-            println!("{:#?}", exits);
+            let etag = etag.as_ref().map(|e| e.as_bytes());
+            let exits = client.run_with_etag(ListExits2 {}, etag).await?;
+            println!("ETag: {:?}", exits.etag().map(String::from_utf8_lossy));
+            match exits.into_body() {
+                Some(r) => println!("{:#?}", r.exits),
+                None => eprintln!("Not Modified"),
+            }
         }
         Commands::ListTunnels => {
             eprintln!("Get all existing tunnels");

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,9 @@
-use crate::cmd::{parse_response, ApiError, ApiErrorKind, Cmd, ProtocolError};
+use crate::cmd::{parse_response, ApiError, ApiErrorKind, Cmd, ETagCmd, ProtocolError};
+use crate::response::Response;
 use crate::token::AcquireToken;
 use crate::types::{AccountId, AuthToken};
 use anyhow::{anyhow, Context};
+use http::HeaderValue;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -69,8 +71,8 @@ impl Client {
         let account_id = self.account_id.clone();
         let request = AcquireToken { account_id }.to_request(&self.base_url)?;
         let res = self.send_http(request).await?;
-        let auth_token: String = parse_response(res).await?;
-        let auth_token: AuthToken = auth_token.into();
+        let res = parse_response::<String>(res).await?;
+        let auth_token: AuthToken = res.into_body().context("No auth token in response")?.into();
         self.set_auth_token(Some(auth_token.clone()));
 
         drop(acquiring_auth_token);
@@ -91,9 +93,22 @@ impl Client {
     }
 
     pub async fn run<C: Cmd>(&self, cmd: C) -> Result<C::Output, ClientError> {
+        let r = self.run_impl(cmd, None).await?;
+        let Some(body) = r.into_body() else {
+            return Err(anyhow::Error::msg("Non-conditional request has no body.").into());
+        };
+        Ok(body)
+    }
+
+    pub async fn run_with_etag<C: ETagCmd>(&self, cmd: C, etag: Option<&[u8]>) -> Result<Response<C::Output>, ClientError> {
+        self.run_impl(cmd, etag).await
+    }
+
+    async fn run_impl<C: Cmd>(&self, cmd: C, etag: Option<&[u8]>) -> Result<Response<C::Output>, ClientError> {
+        let etag = etag.map(HeaderValue::from_bytes).transpose().map_err(anyhow::Error::new)?;
         for _ in 0..3 {
             let auth_token = self.acquire_auth_token().await?;
-            if let Some(output) = self.try_run::<C>(&cmd, &auth_token).await? {
+            if let Some(output) = self.run_once::<C>(&cmd, &auth_token, etag.clone()).await? {
                 return Ok(output);
             }
             self.clear_auth_token(auth_token);
@@ -104,8 +119,13 @@ impl Client {
 
     // Sends the http request and maps expected error codes to client errors.
     // Returns `Ok(None)` if the auth token is invalid, because this error shouldn't bubble up.
-    async fn try_run<C: Cmd>(&self, body: &C, auth_token: &AuthToken) -> Result<Option<C::Output>, ClientError> {
-        let request = body.to_request(&self.base_url, auth_token)?;
+    async fn run_once<C: Cmd>(
+        &self,
+        body: &C,
+        auth_token: &AuthToken,
+        etag: Option<HeaderValue>,
+    ) -> Result<Option<Response<C::Output>>, ClientError> {
+        let request = body.to_request(&self.base_url, auth_token, etag)?;
         let res = self.send_http(request).await?;
         match parse_response(res).await {
             Ok(output) => Ok(Some(output)),

--- a/src/cmd/exit.rs
+++ b/src/cmd/exit.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::OneExit;
+use crate::{cmd::ETagCmd, types::OneExit};
 
 use super::Cmd;
 
@@ -14,6 +14,8 @@ impl Cmd for ListExits {
     const METHOD: http::Method = http::Method::GET;
     const PATH: &'static str = EXITS_PATH;
 }
+
+impl ETagCmd for ListExits {}
 
 #[test]
 fn test_json() {

--- a/src/cmd/exit2.rs
+++ b/src/cmd/exit2.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::OneExit;
+use crate::{cmd::ETagCmd, types::OneExit};
 
 use super::Cmd;
 
@@ -19,6 +19,8 @@ impl Cmd for ListExits2 {
     const METHOD: http::Method = http::Method::GET;
     const PATH: &'static str = EXITS_PATH;
 }
+
+impl ETagCmd for ListExits2 {}
 
 #[test]
 fn test_json() {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -14,6 +14,8 @@ pub use account::*;
 pub use cache_wg_key::*;
 pub use exit::*;
 pub use exit2::*;
+use http::HeaderValue;
+use http::StatusCode;
 pub use lightning::*;
 pub use newsletter_subscribe::*;
 pub use newsletter_unsubscribe::*;
@@ -28,6 +30,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
+use crate::response::Response;
 use crate::types::AuthToken;
 use crate::ClientError;
 
@@ -36,7 +39,7 @@ pub trait Cmd: Serialize + DeserializeOwned + std::fmt::Debug {
     const METHOD: http::Method;
     const PATH: &'static str;
 
-    fn to_request(&self, base_url: impl AsRef<str>, auth_token: &AuthToken) -> anyhow::Result<http::Request<String>> {
+    fn to_request(&self, base_url: impl AsRef<str>, auth_token: &AuthToken, etag: Option<HeaderValue>) -> anyhow::Result<http::Request<String>> {
         let url = Url::parse(base_url.as_ref())?.join(Self::PATH)?;
         let mut request = http::Request::builder()
             .method(Self::METHOD)
@@ -44,12 +47,17 @@ pub trait Cmd: Serialize + DeserializeOwned + std::fmt::Debug {
             .header(http::header::AUTHORIZATION, format!("Bearer {}", auth_token.as_str()))
             .header(http::header::CONTENT_TYPE, "application/json")
             .body(String::new())?;
+        if let Some(etag) = etag {
+            request.headers_mut().insert(http::header::IF_NONE_MATCH, etag);
+        }
         if Self::METHOD != http::Method::GET {
             *request.body_mut() = serde_json::to_string(self)?;
         }
         Ok(request)
     }
 }
+
+pub trait ETagCmd: Cmd {}
 
 #[derive(Clone, Debug, Error)]
 #[error("{}", self.body.msg)]
@@ -95,7 +103,7 @@ pub struct ProtocolError {
     pub source: anyhow::Error,
 }
 
-pub async fn parse_response<T: 'static + DeserializeOwned>(res: reqwest::Response) -> Result<T, ClientError> {
+pub async fn parse_response<T: 'static + DeserializeOwned>(res: reqwest::Response) -> Result<Response<T>, ClientError> {
     let is_json = res
         .headers()
         .get(http::header::CONTENT_TYPE)
@@ -116,8 +124,13 @@ pub async fn parse_response<T: 'static + DeserializeOwned>(res: reqwest::Respons
         };
     }
 
+    let etag = res.headers().get(http::header::ETAG).cloned();
+
     let status = res.status();
-    if !status.is_success() {
+
+    let body = if status == StatusCode::NOT_MODIFIED {
+        None
+    } else if !status.is_success() {
         return Err(ClientError::ApiError(ApiError {
             status,
             body: res.json().await.map_err(|err| {
@@ -128,12 +141,16 @@ pub async fn parse_response<T: 'static + DeserializeOwned>(res: reqwest::Respons
                 })
             })?,
         }));
-    }
-    let empty: Box<dyn Any> = Box::new(());
-    if let Ok(empty) = empty.downcast::<T>() {
-        return Ok(*empty);
-    }
-    Ok(res.json().await.map_err(anyhow::Error::new)?)
+    } else {
+        let empty: Box<dyn Any> = Box::new(());
+        Some(if let Ok(empty) = empty.downcast::<T>() {
+            *empty
+        } else {
+            res.json().await.map_err(anyhow::Error::new)?
+        })
+    };
+
+    Ok(Response::new(body, etag))
 }
 
 #[cfg(test)]

--- a/src/cmd/prices.rs
+++ b/src/cmd/prices.rs
@@ -1,5 +1,5 @@
 use super::Cmd;
-use crate::types::Prices;
+use crate::{cmd::ETagCmd, types::Prices};
 use serde::{Deserialize, Serialize};
 
 const PRICES_PATH: &str = "prices";
@@ -12,6 +12,8 @@ impl Cmd for ListPrices {
     const METHOD: http::Method = http::Method::GET;
     const PATH: &'static str = PRICES_PATH;
 }
+
+impl ETagCmd for ListPrices {}
 
 #[test]
 fn test_json() {

--- a/src/cmd/relay.rs
+++ b/src/cmd/relay.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::OneRelay;
+use crate::{cmd::ETagCmd, types::OneRelay};
 
 use super::Cmd;
 
@@ -14,6 +14,8 @@ impl Cmd for ListRelays {
     const METHOD: http::Method = http::Method::GET;
     const PATH: &'static str = RELAYS_PATH;
 }
+
+impl ETagCmd for ListRelays {}
 
 #[test]
 fn test_json() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ mod client;
 #[cfg(feature = "client")]
 pub mod notices;
 pub mod relay_protocol;
+#[cfg(feature = "client")]
+mod response;
 
 #[cfg(feature = "client")]
 pub use client::Client;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,21 @@
+pub struct Response<T> {
+    body: Option<T>,
+    etag: Option<http::HeaderValue>,
+}
+
+impl<T> Response<T> {
+    pub(crate) fn new(body: Option<T>, etag: Option<http::HeaderValue>) -> Self {
+        Response { body, etag }
+    }
+
+    pub fn etag(&self) -> Option<&[u8]> {
+        self.etag.as_ref().map(|h| h.as_bytes())
+    }
+
+    /// Get the response body.
+    ///
+    /// This will be None only if the response was a 304 Not Modified.
+    pub fn into_body(self) -> Option<T> {
+        self.body
+    }
+}


### PR DESCRIPTION
- This adds a new method for making a conditional request.
- The underlying implementation is shared with a type that can be extended to more request metadata in the future.
- API Endpoints that support conditional requests are tagged to let callers know which endpoints support caching.

Fixes: https://linear.app/soveng/issue/OBS-1632/add-conditional-request-support-to-api-client