### PR TITLE
Update the `gen_id` example to create full-entropy account numbers.

### DIFF
--- a/examples/gen_id.rs
+++ b/examples/gen_id.rs
@@ -2,12 +2,10 @@ use rand::Rng;
 use verhoeff::Verhoeff;
 
 pub const ACCOUNT_ID_LEN: usize = 20;
-
-#[allow(dead_code)]
 const ACCOUNT_ID_MAX: u64 = 10u64.pow(ACCOUNT_ID_LEN as u32 - 1) - 1;
 
 fn main() {
-    let id = rand::thread_rng().gen_range(0..=i64::MAX as u64);
+    let id = rand::thread_rng().gen_range(0..=ACCOUNT_ID_MAX);
     let without_check_digit = format!("{:019}", id);
     let check_digit = without_check_digit.calculate_verhoeff_check_digit();
     println!("{without_check_digit}{check_digit}");


### PR DESCRIPTION
The range was originally limited to i64 to making working with the unchecked account number simpler in some situations, however it isn't worth having this command generated numbers with less entropy without notice.

The account number generator in the macOS client and website have always generated numbers with the full entropy. So this only affects numbers manually generate during testing.