### PR TITLE
fall back to alternative host if there is a network error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,7 @@ dependencies = [
  "qrcode",
  "rand",
  "reqwest",
+ "rustls",
  "semver",
  "serde",
  "serde_json",
@@ -848,6 +849,7 @@ dependencies = [
  "url",
  "uuid",
  "verhoeff",
+ "webpki-roots",
  "x25519-dalek",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,12 @@ tokio = { version = "1", default-features = false, features = ["net"] }
 tracing = "0.1.40"
 url = "2"
 uuid = { version = "1.11.0", features = ["v4", "serde"] }
+rustls = { version = "0.22.4", optional = true }
+webpki-roots = { version = "0.26.1", optional = true }
 
 [features]
 default = ["client"]
-client = ["reqwest"]
+client = ["reqwest", "rustls", "webpki-roots"]
 server = []
 
 [dev-dependencies]

--- a/examples/api_cli.rs
+++ b/examples/api_cli.rs
@@ -66,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
     let url = args.base_url;
     let account_id = AccountId::from_string_unchecked(args.account_no);
 
-    let client = Client::new(url, account_id, "example cli client")?;
+    let client = Client::new(url, vec![], account_id, "example cli client")?;
 
     eprintln!("Get account info");
     let account_info = client.run(GetAccountInfo()).await?;

--- a/examples/block_test.rs
+++ b/examples/block_test.rs
@@ -4,6 +4,7 @@ use obscuravpn_api::types::AccountId;
 use obscuravpn_api::{Client, ClientError};
 
 const API_URL: &str = "https://v1.api.prod.obscura.net/api";
+const ALTERNATIVE_HOST: &str = "crimsonlance.net";
 
 #[derive(Parser, Debug, PartialEq)]
 #[command(author, version, about, long_about = None)]
@@ -18,8 +19,9 @@ async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let args = Args::parse();
     let account_id = AccountId::from_string_unchecked(args.account_no);
+    let alternative_hosts = vec![ALTERNATIVE_HOST.to_string()];
 
-    let client = Client::new(API_URL, account_id, "block test cli client")?;
+    let client = Client::new(API_URL, alternative_hosts, account_id, "block test cli client")?;
     match client.acquire_auth_token().await {
         Ok(_) => println!("not blocked"),
         Err(error) => match error {
@@ -39,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
                 bail!("invalid request header value");
             }
             ClientError::Other(error) => {
-                bail!("other error: {}", error);
+                bail!("other error: {:?}", error);
             }
         },
     };

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,7 @@ use crate::types::{AccountId, AuthToken};
 use anyhow::{anyhow, Context};
 use http::HeaderValue;
 use reqwest::ClientBuilder;
+use rustls::client::WebPkiServerVerifier;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -14,6 +15,7 @@ use thiserror::Error;
 pub struct Client {
     account_id: AccountId,
     base_url: String,
+    alternative_hosts: Vec<String>,
     http: reqwest::Client,
     http_no_sni: reqwest::Client,
     cached_auth_token: Arc<Mutex<Option<AuthToken>>>,
@@ -38,18 +40,13 @@ pub enum ClientError {
 }
 
 impl Client {
-    pub fn new(base_url: impl ToString, account_id: AccountId, user_agent: &str) -> anyhow::Result<Self> {
+    pub fn new(base_url: impl ToString, alternative_hosts: Vec<String>, account_id: AccountId, user_agent: &str) -> anyhow::Result<Self> {
         let mut base_url = base_url.to_string();
         if !base_url.ends_with('/') {
             base_url += "/"
         }
-        let http = Self::http_client_builder(user_agent)
-            .build()
-            .context("failed to initialize HTTP client")?;
-        let http_no_sni = Self::http_client_builder(user_agent)
-            .tls_sni(false)
-            .build()
-            .context("failed to initialize no-sni HTTP client")?;
+        let http = Self::http_client_builder(user_agent, false)?;
+        let http_no_sni = Self::http_client_builder(user_agent, true)?;
 
         Ok(Self {
             account_id,
@@ -58,14 +55,22 @@ impl Client {
             http,
             http_no_sni,
             acquiring_auth_token: tokio::sync::Mutex::new(()),
+            alternative_hosts,
         })
     }
 
-    fn http_client_builder(user_agent: &str) -> ClientBuilder {
-        ClientBuilder::new()
+    fn http_client_builder(user_agent: &str, no_sni: bool) -> anyhow::Result<reqwest::Client> {
+        let builder = ClientBuilder::new()
             .timeout(Duration::from_secs(60))
             .read_timeout(Duration::from_secs(10))
-            .user_agent(user_agent)
+            .user_agent(user_agent);
+        let builder = if no_sni {
+            builder.tls_sni(false)
+        } else {
+            builder.use_preconfigured_tls(Self::rustls_config()?)
+        };
+        let client = builder.build().context("failed to initialize HTTP client")?;
+        Ok(client)
     }
 
     fn clear_auth_token(&self, token: AuthToken) {
@@ -106,17 +111,48 @@ impl Client {
 
     async fn send_http(&self, request: http::Request<String>) -> Result<reqwest::Response, ClientError> {
         let reqwest_request: reqwest::Request = request.clone().try_into().context("could not construct reqwest::Request")?;
-        match self.http.execute(reqwest_request).await {
+        let first_error = match self.http.execute(reqwest_request).await {
             Ok(resp) => return Ok(resp),
-            Err(error) => tracing::error!("error executing request, maybe blocked, trying again without SNI: {:?}", error),
+            Err(error) => {
+                tracing::error!(
+                    message_id = "XfTLkg6w",
+                    ?error,
+                    "error executing request, maybe blocked, trying again with alternative hosts",
+                );
+                error
+            }
+        };
+
+        for host in &self.alternative_hosts {
+            let mut reqwest_request: reqwest::Request = request.clone().try_into().context("could not construct reqwest::Request")?;
+            if let Err(error) = reqwest_request.url_mut().set_host(Some(host.as_str())) {
+                tracing::error!(message_id = "6mXOeRSL", host, ?error, "failed to set alternative host on request");
+                continue;
+            };
+            match self.http.execute(reqwest_request).await {
+                Ok(resp) => return Ok(resp),
+                Err(error) => tracing::error!(
+                    message_id = "m6JLZaYN",
+                    host,
+                    ?error,
+                    "error executing request with alternative host, maybe blocked"
+                ),
+            }
         }
 
+        tracing::error!("all attempts to evade blocks using alternative hosts failed, trying again without SNI");
         let reqwest_request: reqwest::Request = request.clone().try_into().context("could not construct reqwest::Request")?;
-        self.http_no_sni
-            .execute(reqwest_request)
-            .await
-            .context("error executing request")
-            .map_err(Into::into)
+        match self.http_no_sni.execute(reqwest_request).await {
+            Ok(resp) => return Ok(resp),
+            Err(error) => tracing::error!(
+                message_id = "CttGsdTj",
+                ?error,
+                "error executing request without SNI, maybe blocked, trying again with alternative hosts"
+            ),
+        }
+
+        tracing::error!(message_id = "QmAdyhxm", "all attempts to evade blocks failed, returning original error");
+        Err(first_error.into())
     }
 
     pub async fn run<C: Cmd>(&self, cmd: C) -> Result<C::Output, ClientError> {
@@ -163,5 +199,75 @@ impl Client {
             },
             Err(err) => Err(err),
         }
+    }
+
+    fn rustls_config() -> anyhow::Result<rustls::ClientConfig> {
+        let crypto = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(VerifyApiServerCert::new()?)
+            .with_no_client_auth();
+        Ok(crypto)
+    }
+}
+
+#[derive(Debug)]
+struct VerifyApiServerCert {
+    server_name: rustls::pki_types::ServerName<'static>,
+    web_pki_server_verifier: Arc<dyn rustls::client::danger::ServerCertVerifier>,
+}
+
+impl VerifyApiServerCert {
+    fn new() -> anyhow::Result<Arc<Self>> {
+        let roots = rustls::RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+        };
+        let web_pki_server_verifier = WebPkiServerVerifier::builder(roots.into()).build()?;
+        let server_name = rustls::pki_types::ServerName::try_from("v1.api.prod.obscura.net")?;
+        Ok(Arc::new(Self {
+            server_name,
+            web_pki_server_verifier,
+        }))
+    }
+}
+
+impl rustls::client::danger::ServerCertVerifier for VerifyApiServerCert {
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls::pki_types::CertificateDer<'_>,
+        intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        server_name: &rustls::pki_types::ServerName<'_>,
+        ocsp_response: &[u8],
+        now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        if server_name.to_str() != self.server_name.to_str() {
+            tracing::info!(
+                message_id = "jx7gpGq8",
+                verify_server_name = %self.server_name.to_str(),
+                request_server_name = %server_name.to_str(),
+                "verifying server certificate with different server name",
+            );
+        }
+        self.web_pki_server_verifier
+            .verify_server_cert(end_entity, intermediates, &self.server_name, ocsp_response, now)
+    }
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.web_pki_server_verifier.verify_tls12_signature(message, cert, dss)
+    }
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.web_pki_server_verifier.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.web_pki_server_verifier.supported_verify_schemes()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,5 @@ pub use client::Client;
 pub use client::ClientError;
 #[cfg(feature = "client")]
 pub use response::Response;
+#[cfg(feature = "client")]
+pub use rustls;


### PR DESCRIPTION
This does not work with fake SNIs that don't have a DNS entry that points to our server (separate PR incoming).