### PR TITLE
Extend subscription API to handle waitlist.

### DIFF
--- a/src/cmd/newsletter_subscribe.rs
+++ b/src/cmd/newsletter_subscribe.rs
@@ -1,10 +1,21 @@
+use crate::types::SubscriptionTarget;
 use serde::{Deserialize, Serialize};
 
 use super::Cmd;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NewsletterSubscribe {
-    pub email: String,
+    /// DEPRECATED, use `target`.
+    pub email: Option<String>,
+
+    /// Required, optional for migration only.
+    pub target: Option<SubscriptionTarget>,
+
+    /// Set of subscriptions to subscribe to, they are identified by strings.
+    ///
+    /// This is required, for legacy reasons if not provided or empty it defaults to the general newsletter.
+    #[serde(default)]
+    pub subscriptions: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -25,7 +36,61 @@ fn test_json() {
         Some(
             r#"
             {
-                "email": "me@example"
+                "email": null,
+                "subscriptions": [
+                    "blog"
+                ],
+                "target": {
+                    "type": "email",
+                    "addr": "me@example",
+                    "pgp_fingerprint": "B66B891DD83B0E677D84FC309BB92CC1552E99AA"
+                }
+            }
+            "#,
+        ),
+        Some(
+            r#"
+            {
+                "id": 37,
+                "unsubscribe_secret": "29dcf763-962f-4f6f-8aa0-98cd751bd208"
+            }
+            "#,
+        ),
+    );
+
+    crate::cmd::check_cmd_json::<NewsletterSubscribe>(
+        Some(
+            r#"
+            {
+                "email": null,
+                "subscriptions": [
+                    "platform-windows",
+                    "platform-android"
+                ],
+                "target": {
+                    "type": "nostr",
+                    "addr": "me@example"
+                }
+            }
+            "#,
+        ),
+        Some(
+            r#"
+            {
+                "id": 37,
+                "unsubscribe_secret": "29dcf763-962f-4f6f-8aa0-98cd751bd208"
+            }
+            "#,
+        ),
+    );
+
+    crate::cmd::check_cmd_json::<NewsletterSubscribe>(
+        Some(
+            r#"
+            {
+                "email": "me@example",
+                "subscriptions": [],
+                "target": null
             }
             "#,
         ),

--- a/src/types.rs
+++ b/src/types.rs
@@ -99,6 +99,13 @@ impl StripeSubscriptionInfo {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SubscriptionTarget {
+    Email { addr: String, pgp_fingerprint: Option<String> },
+    Nostr { addr: String },
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AppleSubscriptionInfo {
     /// https://developer.apple.com/documentation/appstoreserverapi/status


### PR DESCRIPTION
1. Support PGP keys.
2. Support Nostr.
3. Allow selecting which "newsletters" to subscribe to.

For now we retain `email` for compatibility but this can be removed once the website is updated.

Fixes: https://linear.app/soveng/issue/OBS-2074/update-newsletter-api-to-support-waitlist