### PR TITLE
Require original transaction ID

### DIFF
--- a/src/cmd/apple/poll_subscription.rs
+++ b/src/cmd/apple/poll_subscription.rs
@@ -5,12 +5,14 @@ use serde::{Deserialize, Serialize};
 pub struct ApplePollSubscriptionOutput {}
 
 /// This is used as a fallback to recover from discrepancies between the client
-/// and server subscription state, i.e. if the user made their first
-/// transaction during an outage.
+/// and server subscription state, i.e.:
+/// - Setting the app account token after an offer code redemption.
+/// - If the user made their first transaction during an outage.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ApplePollSubscription {
-    /// Any transaction ID known by the client for this account.
-    pub transaction_id: String,
+    // TODO: Rename this field if we ever bump the API version
+    #[serde(rename = "transaction_id")]
+    pub original_transaction_id: String,
 }
 
 impl Cmd for ApplePollSubscription {


### PR DESCRIPTION
Contributes to https://linear.app/soveng/issue/OBS-2121/apple-subscription-does-not-work

This is technically a breaking change, but should be inconsequential in practice.