### PR TITLE
Rename `subscription` to `stripe_subscription`.

### DIFF
--- a/src/cmd/account/info.rs
+++ b/src/cmd/account/info.rs
@@ -18,6 +18,7 @@ fn test_account_info_json() {
           "id": "0000000000000000000",
           "active": true,
           "top_up": { "credit_expires_at": 1000 },
+          "stripe_subscription": null,
           "subscription": null,
           "apple_subscription": null,
           "google_subscription": null,

--- a/src/types.rs
+++ b/src/types.rs
@@ -71,13 +71,13 @@ pub struct AccountInfo {
     pub id: AccountId,
     pub active: bool,
     pub top_up: Option<TopUp>,
-    // TODO: Rename this field if we ever bump the API version
-    #[serde(rename = "subscription")]
-    pub stripe_subscription: Option<StripeSubscriptionInfo>,
     pub apple_subscription: Option<AppleSubscriptionInfo>,
     #[serde(default)]
     pub google_subscription: Option<GoogleSubscriptionInfo>,
     pub monero_pending_payments: Vec<MoneroPaymentInProgress>,
+    pub stripe_subscription: Option<StripeSubscriptionInfo>,
+    #[cfg(feature = "server")]
+    pub subscription: Option<StripeSubscriptionInfo>,
     /// True if the user made any payment in the past.
     pub has_paid: bool,
     pub free_month_on_next_payment: bool,


### PR DESCRIPTION
Clients will use the new field. The server will emit both for now.

Fixes: https://linear.app/soveng/issue/OBS-3728/rename-subscription-to-stripe-subscription-in-api