### PR TITLE
Add active field to all funding types.

### DIFF
--- a/src/cmd/account/info.rs
+++ b/src/cmd/account/info.rs
@@ -17,7 +17,10 @@ fn test_account_info_json() {
         {
           "id": "0000000000000000000",
           "active": true,
-          "top_up": { "credit_expires_at": 1000 },
+          "top_up": {
+            "active": true,
+            "credit_expires_at": 1000
+          },
           "stripe_subscription": null,
           "subscription": null,
           "apple_subscription": null,

--- a/src/types.rs
+++ b/src/types.rs
@@ -99,11 +99,13 @@ pub struct AccountInfo {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TopUp {
+    pub active: bool,
     pub credit_expires_at: i64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StripeSubscriptionInfo {
+    pub active: bool,
     /// string repr of [`stripe::SubscriptionStatus`][https://docs.rs/async-stripe/latest/stripe/enum.SubscriptionStatus.html]
     pub status: String,
     /// period start in seconds since unix epoch
@@ -112,17 +114,6 @@ pub struct StripeSubscriptionInfo {
     pub current_period_end: i64,
     /// whether the subscription will end at this period
     pub cancel_at_period_end: bool,
-}
-
-impl StripeSubscriptionInfo {
-    pub fn new(status: String, current_period_start: i64, current_period_end: i64, cancel_at_period_end: bool) -> Self {
-        Self {
-            status,
-            current_period_start,
-            current_period_end,
-            cancel_at_period_end,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Deserialize, Serialize)]
@@ -145,6 +136,7 @@ impl SubscriptionTarget {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AppleSubscriptionInfo {
+    pub active: bool,
     /// https://developer.apple.com/documentation/appstoreserverapi/status
     pub status: u8,
     /// Whether the subscription will renew automatically


### PR DESCRIPTION
This makes it trivial for clients to understand if a particular funding method is active without knowing about the various statuses and rules. This also makes sure that frontends stay in sync with the conclusion of the server.

Fixes: https://linear.app/soveng/issue/OBS-3727/add-active-field-to-all-funding-types