### PR TITLE
Add integer values for Monero.

### DIFF
--- a/src/cmd/monero/check.rs
+++ b/src/cmd/monero/check.rs
@@ -1,11 +1,18 @@
 use crate::cmd::Cmd;
 use serde::{Deserialize, Serialize};
 
+#[serde_with::serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CheckMoneroTopUpInfo {
-    pub status: MoneroPaymentStatus,
+    #[deprecated]
     pub amount_expected: f64,
+    #[deprecated]
     pub amount_received: f64,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub expected_piconero: u64,
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub received_piconero: u64,
+    pub status: MoneroPaymentStatus,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -43,9 +50,11 @@ fn test_json_paid() {
     "#;
     let output_json = r#"
     {
-      "status": "paid",
       "amount_expected": 0.02,
-      "amount_received": 0.02
+      "amount_received": 0.02,
+      "expected_piconero": "20000000000",
+      "received_piconero": "20000000000",
+      "status": "paid"
     }
     "#;
     crate::cmd::check_cmd_json::<CheckMoneroTopUp>(Some(cmd_json), Some(output_json));
@@ -60,9 +69,11 @@ fn test_json_confirming() {
     "#;
     let output_json = r#"
     {
-      "status": "confirming",
       "amount_expected": 0.002,
-      "amount_received": 0.002
+      "amount_received": 0.002,
+      "expected_piconero": "2000000000",
+      "received_piconero": "2000000000",
+      "status": "confirming"
     }
     "#;
     crate::cmd::check_cmd_json::<CheckMoneroTopUp>(Some(cmd_json), Some(output_json));
@@ -77,9 +88,11 @@ fn test_json_unpaid() {
     "#;
     let output_json = r#"
     {
-      "status": "unpaid",
       "amount_expected": 0.05,
-      "amount_received": 0.0
+      "amount_received": 0.0,
+      "expected_piconero": "50000000000",
+      "received_piconero": "0",
+      "status": "unpaid"
     }
     "#;
     crate::cmd::check_cmd_json::<CheckMoneroTopUp>(Some(cmd_json), Some(output_json));
@@ -94,9 +107,11 @@ fn test_json_bad_payment() {
     "#;
     let output_json = r#"
     {
-      "status": "partially_paid",
       "amount_expected": 0.05,
-      "amount_received": 0.04
+      "amount_received": 0.04,
+      "expected_piconero": "50000000000",
+      "received_piconero": "40000000000",
+      "status": "partially_paid"
     }
     "#;
     crate::cmd::check_cmd_json::<CheckMoneroTopUp>(Some(cmd_json), Some(output_json));


### PR DESCRIPTION
Fixes: https://linear.app/soveng/issue/OBS-3726/convert-monero-amount-to-integer